### PR TITLE
Adds timestamps to the log format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Logger - Logging singleton for Godot Engine
 The *Logger* class is a GDScript singleton that provides a logging API for
 projects developed with [Godot Engine](https://godotengine.org).
 
-Usage
------
+# Usage
 
 Copy the `logger.gd` file into your project folder, and define it as an autoloaded
 singleton in your project's settings (e.g. with the name *Logger*):
@@ -16,14 +15,65 @@ Logger="*res://logger.gd"
 The methods of the API can then be accessed from any other script via the *Logger*
 singleton:
 ```
-  Logger.warn('alpaca mismatch!')
-  Logger.info('reticulating splines...', mymodule)
+  Logger.warn("Alpaca mismatch!")
+
+  Logger.add_module("mymodule")
+  Logger.info("Reticulating splines...", "mymodule")
 ```
 
 Read the code for details about the API, it's extensively documented.
 
-Licensing
----------
+## Output format configuration
+
+The `output_format` property can be customized using format fields from the
+`FORMAT_IDS` dictionary. They are placeholders which will be replaced by the
+relevant content.
+
+**Log format fields**:
+
+* `{LVL}`  = Level of the log
+* `{MOD}`  = Module that does the logging
+* `{MSG}`  = Message from the user
+* `{TIME}` = Timestamp when the logging occurred
+
+The timestamp format can be configured for each module using the `time_format`
+property, with the placeholders described below.
+
+**Timestamp fields**:
+
+* `YYYY` = Year
+* `MM` = Month
+* `DD` = Day
+* `hh` = Hour
+* `mm` = Minute
+* `ss` = Second
+
+### Example
+
+```gdscript
+var msg = "Error occurred!"
+
+Logger.output_format = "[{TIME}] [{LVL}] [{MOD}] {MSG}"
+Logger.time_format = "YYYY.MM.DD hh:mm:ss"
+Logger.error(msg)
+
+Logger.time_format = "hh:mm:ss"
+Logger.error(msg)
+
+Logger.output_format = "[{LVL}] {MSG} at {TIME}"
+Logger.error(msg)
+```
+
+Results in:
+```
+[2020.10.09 12:10:47] [ERROR] [main] Error occurred!
+
+[12:10:47] [ERROR] [main] Error occurred!
+
+[ERROR] Error occurred! at 12:10:47
+```
+
+## Licensing
 
 The Logger class and all other files of this repository are distributed under the
 MIT license (see the LICENSE.md file).

--- a/logger.gd
+++ b/logger.gd
@@ -218,9 +218,10 @@ const MAX_STRATEGY = STRATEGY_MEMORY*2 - 1
 
 # Output format identifiers
 const FORMAT_IDS = {
-  "level": "{LVL}",
-  "module": "{MOD}",
-  "message": "{MSG}"
+	"level": "{LVL}",
+	"module": "{MOD}",
+	"message": "{MSG}",
+	"time": "{TIME}"
 }
 
 # Queue modes
@@ -243,7 +244,10 @@ var default_logfile_path = "user://%s.log" % ProjectSettings.get_setting("applic
 var default_configfile_path = "user://%s.cfg" % PLUGIN_NAME
 
 # e.g. "[INFO] [main] The young alpaca started growing a goatie."
-var output_format = "[{LVL}] [{MOD}] {MSG}"
+var output_format = "[{TIME}] [{LVL}] [{MOD}] {MSG}"
+# Example with all supported placeholders: "YYYY.MM.DD hh.mm.ss"
+# would output e.g.: "2020.10.09 12:10:47".
+var time_format = "hh:mm:ss"
 
 # Holds the name of the debug module for easy usage across all logging functions.
 var default_module_name = "main"
@@ -441,11 +445,30 @@ func get_default_output_level():
 # Output formatting
 # -----------------
 
-static func format(template, level, module, message):
+# Format the fields:
+# * YYYY = Year
+# * MM = Month
+# * DD = Day
+# * hh = Hour
+# * mm = Minutes
+# * ss = Seconds
+func get_formatted_datetime():
+	var datetime = OS.get_datetime()
+	var result = time_format
+	result = result.replacen("YYYY", "%04d" % [datetime.year])
+	result = result.replacen("MM", "%02d" % [datetime.month])
+	result = result.replacen("DD", "%02d" % [datetime.day])
+	result = result.replacen("hh", "%02d" % [datetime.hour])
+	result = result.replacen("mm", "%02d" % [datetime.minute])
+	result = result.replacen("ss", "%02d" % [datetime.second])
+	return result
+
+func format(template, level, module, message):
 	var output = template
 	output = output.replace(FORMAT_IDS.level, LEVELS[level])
 	output = output.replace(FORMAT_IDS.module, module)
 	output = output.replace(FORMAT_IDS.message, message)
+	output = output.replace(FORMAT_IDS.time, get_formatted_datetime())
 	return output
 
 func set_output_format(new_format):


### PR DESCRIPTION
Add timestamps to be used in the log format.
And updates the README.md to reflect the changes and give more insight to the formatting options.

### Example:
```gdscript
var msg: String = "Error occurred!"

Logger.get_module("main").time_template = "dd.mm.yyyy hh:MM:ss"
Logger.error(msg)

Logger.get_module("main").time_template = "hh:MM:ss"
Logger.error(msg)

Logger.output_format = "[{LVL}] {MSG} at {TIME}"
Logger.error(msg)
```

Results in:
![log_formating](https://user-images.githubusercontent.com/20865283/95575893-d0ef0c80-0a2f-11eb-8101-0167e8050dd2.png)

I mentioned a timestamp system in #9 