### PR TITLE
Make sure the logger can log objects also.

### DIFF
--- a/logger.gd
+++ b/logger.gd
@@ -531,6 +531,8 @@ func get_formatted_datetime():
 
 
 func format(template, level, module, message, error_code = -1):
+	if typeof(message) == TYPE_OBJECT:
+		message = str(message)
 	var output = template
 	output = output.replace(FORMAT_IDS.level, LEVELS[level])
 	output = output.replace(FORMAT_IDS.module, module)

--- a/logger.gd
+++ b/logger.gd
@@ -531,11 +531,10 @@ func get_formatted_datetime():
 
 
 func format(template, level, module, message, error_code = -1):
-	message = str(message)
 	var output = template
 	output = output.replace(FORMAT_IDS.level, LEVELS[level])
 	output = output.replace(FORMAT_IDS.module, module)
-	output = output.replace(FORMAT_IDS.message, message)
+	output = output.replace(FORMAT_IDS.message, str(message))
 	output = output.replace(FORMAT_IDS.time, get_formatted_datetime())
 
 	# Error message substitution

--- a/logger.gd
+++ b/logger.gd
@@ -531,8 +531,7 @@ func get_formatted_datetime():
 
 
 func format(template, level, module, message, error_code = -1):
-	if typeof(message) == TYPE_OBJECT:
-		message = str(message)
+	message = str(message)
 	var output = template
 	output = output.replace(FORMAT_IDS.level, LEVELS[level])
 	output = output.replace(FORMAT_IDS.module, module)


### PR DESCRIPTION
My case is, I went on and implemented this by replacing all my "print/printerr" with "Logger.xxx" but sometime i was logging objects (classes basically with fields) and logger crashes there.
![image](https://user-images.githubusercontent.com/1850856/106015146-77821a80-60be-11eb-817f-795071a2c083.png)
So this is a simple fix to be able to log objects also.
