### PR TITLE
Normalization of millisecond times

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ property, with the placeholders described below.
 * `hh` = Hour
 * `mm` = Minute
 * `ss` = Second
+* `SSS` = Millisecond
 
 **Error codes:**
 
@@ -65,7 +66,7 @@ Logger.error("Failed to rotate the albatross", "main", ERR_INVALID_DATA)
 var msg = "Error occurred!"
 
 Logger.output_format = "[{TIME}] [{LVL}] [{MOD}] {MSG}"
-Logger.time_format = "YYYY.MM.DD hh:mm:ss"
+Logger.time_format = "YYYY.MM.DD hh:mm:ss.SSS"
 Logger.error(msg)
 
 Logger.time_format = "hh:mm:ss"
@@ -77,7 +78,7 @@ Logger.error(msg)
 
 Results in:
 ```
-[2020.10.09 12:10:47] [ERROR] [main] Error occurred!
+[2020.10.09 12:10:47.034] [ERROR] [main] Error occurred!
 
 [12:10:47] [ERROR] [main] Error occurred!
 

--- a/logger.gd
+++ b/logger.gd
@@ -334,8 +334,8 @@ var default_configfile_path = "user://%s.cfg" % PLUGIN_NAME
 
 # e.g. "[INFO] [main] The young alpaca started growing a goatie."
 var output_format = "[{TIME}] [{LVL}] [{MOD}]{ERR_MSG} {MSG}"
-# Example with all supported placeholders: "YYYY.MM.DD hh.mm.ss"
-# would output e.g.: "2020.10.09 12:10:47".
+# Example with all supported placeholders: "YYYY.MM.DD hh.mm.ss.SSS"
+# would output e.g.: "2020.10.09 12:10:47.034".
 var time_format = "hh:mm:ss"
 
 # Holds the name of the debug module for easy usage across all logging functions.

--- a/logger.gd
+++ b/logger.gd
@@ -569,7 +569,7 @@ func get_default_output_level():
 # * hh = Hour
 # * mm = Minutes
 # * ss = Seconds
-# * ms = Milliseconds
+# * SSS = Milliseconds
 func get_formatted_datetime():
 	var unix_time: float = Time.get_unix_time_from_system()
 	var time_zone: Dictionary = Time.get_time_zone_from_system()
@@ -583,7 +583,7 @@ func get_formatted_datetime():
 	result = result.replace("hh", "%02d" % [datetime.hour])
 	result = result.replace("mm", "%02d" % [datetime.minute])
 	result = result.replace("ss", "%02d" % [datetime.second])
-	result = result.replace("ms", "%03d" % [datetime.millisecond])
+	result = result.replace("SSS", "%03d" % [datetime.millisecond])
 	return result
 
 


### PR DESCRIPTION
SSS is generally used to represent milliseconds, and it also indicates that the milliseconds are of length 3. I've also changed the usage example in the README.